### PR TITLE
chore(ci): Added workaround for Travis stages issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ jobs:
         - wget https://github.com/go-task/task/releases/download/v2.4.0/task_linux_amd64.deb
         - sudo dpkg -i task_linux_amd64.deb
         - rm task_linux_amd64.deb
+        - export TRAVIS_JOB_NUMBER=WORKAROUND.1
         - task install
       script:
         - task release


### PR DESCRIPTION
Using stages in Travis CI causes issues with semantic-release and it
continusously think that it's not the main job in the stage and refuses
to run.

https://github.com/semantic-release/semantic-release/issues/390