### PR TITLE
fix(git): Fix update error for existing repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
       env:
         - GO111MODULE=on
 
-      install: go get -u
+      install: go get
 
       before_script:
         - wget https://github.com/go-task/task/releases/download/v2.4.0/task_linux_amd64.deb
@@ -24,7 +24,7 @@ jobs:
       env:
         - GO111MODULE=on
 
-      install: go get -u
+      install: go get
 
       before_script:
         - wget https://github.com/go-task/task/releases/download/v2.4.0/task_linux_amd64.deb
@@ -40,7 +40,7 @@ jobs:
       env:
         - GO111MODULE=on
 
-      install: go get -u
+      install: go get
 
       script:
         - wget https://github.com/go-task/task/releases/download/v2.4.0/task_linux_amd64.deb

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/onsi/ginkgo v1.7.0
-	github.com/onsi/gomega v1.4.3
+	github.com/onsi/ginkgo v1.8.0
+	github.com/onsi/gomega v1.5.0
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,10 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3 h1:RE1xgDvH7imwFD45h+u2SgIfERHlS2yNG4DObb5BSKU=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pelletier/go-buffruneio v0.2.0 h1:U4t4R6YkofJ5xHm3dJzuRpPZ0mr5MMCoAWooScCR7aA=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/gitignore/git_adapter_test.go
+++ b/pkg/gitignore/git_adapter_test.go
@@ -118,7 +118,6 @@ var _ = Describe("GitAdapter", func() {
 			Expect(err).To(BeNil())
 
 			repoPath := path.Join(testDir, "gitignore")
-			fmt.Println(repoPath)
 			Expect(directoryExists(repoPath)).To(BeTrue())
 		})
 
@@ -130,6 +129,28 @@ var _ = Describe("GitAdapter", func() {
 
 			err := adapter.Update()
 
+			Expect(err).ToNot(BeNil())
+		})
+
+		It("should pull changes to an existing repository", func() {
+			err := adapter.Update()
+			Expect(err).To(BeNil())
+
+			err = adapter.Update()
+			Expect(err).To(BeNil())
+
+			repoPath := path.Join(testDir, "gitignore")
+			Expect(directoryExists(repoPath)).To(BeTrue())
+		})
+
+		It("should return an error when the path points at a file instead of a directory", func() {
+			os.RemoveAll(testDir)
+
+			file, err := os.Create(testDir)
+			Expect(err).To(BeNil())
+			file.Close()
+
+			err = adapter.Update()
 			Expect(err).ToNot(BeNil())
 		})
 	})


### PR DESCRIPTION
If the the repository already exists then an exceptionw as being thrown.
This was because we were always assuming that we needed to clone a new
repository but this would break if the directory already exists as a git
repository. In that case, we need should be doing a `git pull` instead.