### PR TITLE
fix(git): Fixed double headers on some options

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -43,11 +43,9 @@ github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
-github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/gomega v1.4.3 h1:RE1xgDvH7imwFD45h+u2SgIfERHlS2yNG4DObb5BSKU=
-github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pelletier/go-buffruneio v0.2.0 h1:U4t4R6YkofJ5xHm3dJzuRpPZ0mr5MMCoAWooScCR7aA=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=

--- a/pkg/gitignore/git_adapter.go
+++ b/pkg/gitignore/git_adapter.go
@@ -1,6 +1,7 @@
 package gitignore
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -81,7 +82,10 @@ func (adapter *GitAdapter) Generate(options []string) (string, error) {
 			return "", errors.Wrap(err, message)
 		}
 
-		builder.WriteString(fmt.Sprintf("### %s ###\n", option))
+		if !bytes.HasPrefix(contents, []byte("###")) {
+			builder.WriteString(fmt.Sprintf("### %s ###\n", option))
+		}
+
 		builder.Write(contents)
 		builder.WriteString("\n")
 	}

--- a/pkg/gitignore/git_adapter_test.go
+++ b/pkg/gitignore/git_adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -110,6 +111,13 @@ var _ = Describe("GitAdapter", func() {
 			Expect(err).To(BeNil())
 
 			Expect(contents).To(ContainSubstring(".doit.db"))
+		})
+
+		It("should not contain duplicate headers", func() {
+			contents, err := adapter.Generate([]string{"Hugo"})
+
+			Expect(err).To(BeNil())
+			Expect(strings.Count(contents, "### Hugo ###")).To(Equal(1))
 		})
 	})
 


### PR DESCRIPTION
In some cases (such as for Hugo) a duplicate header would be printed
since the repo already had a header on it and we were always adding one.